### PR TITLE
Implement sending HTTP form data

### DIFF
--- a/openapi_client_generator/common/http.py
+++ b/openapi_client_generator/common/http.py
@@ -69,7 +69,8 @@ class Client(NamedTuple):
             method.value.upper(),
             url,
             params=query,
-            json=payload,
+            data=payload if headers['content-type'] == 'application/x-www-form-urlencoded' else None,
+            json=payload if headers['content-type'] == 'application/json' else None,
             headers={dasherize(k): v for k, v in headers.items() if v is not None}
         ).prepare()
 

--- a/openapi_client_generator/transformers/__init__.py
+++ b/openapi_client_generator/transformers/__init__.py
@@ -654,12 +654,22 @@ def iter_supported_methods(
             cookie_params=containers[oas.ParamLocation.COOKIE],
         )
 
+        default_headers_type = DEFAULT_HEADERS_TYPE
         if method.request_body:
             for content_type, meta in method.request_body.content.items():
                 if content_type.format in (oas.ContentTypeFormat.JSON,
                                            oas.ContentTypeFormat.ANYTHING,
                                            oas.ContentTypeFormat.FORM_URLENCODED):
                     request_schema = meta.schema
+                    default_headers_type = default_headers_type._replace(
+                        attrs=pvector([
+                            (
+                                item
+                                if item.name != "content_type"
+                                else item._replace(default=f"'{content_type.format.value}'")
+                            )
+                            for item in default_headers_type.attrs
+                        ]))
                     break
             else:
                 request_schema = list(method.request_body.content.items())[-1][1].schema
@@ -717,7 +727,7 @@ def iter_supported_methods(
         path_params_type, _types    = infer_params_type(params.path_params)
         headers_type, headers_types = infer_params_type(params.header_params,
                                                         name_normalizer=lambda x: underscore(x.lower()),
-                                                        default=DEFAULT_HEADERS_TYPE)
+                                                        default=default_headers_type)
 
         yield EndpointMethod(
             name=name,


### PR DESCRIPTION
Hi,

Thanks for writing openapi-client-generator!

What do you think about this change as a start towards full support for HTTP form data (application/x-www-form-urlencoded)? It is not finihed yet:
- there are no tests, I'm thinking of the best way to add them (it might require some refactoring of the test suite), but I thought I'd send the implementation part for your comments first
- the common.http change does not handle ContentTypeFormat.ANYTHING, but, honestly, I have no idea what it should do with that :)

Thanks for looking into this, and keep up the great work!

G'luck,
Peter
